### PR TITLE
Propose to display a note for registration pattern

### DIFF
--- a/src/main/docs/guide/writingTheApp.adoc
+++ b/src/main/docs/guide/writingTheApp.adoc
@@ -14,11 +14,14 @@ As shown in the previous image, the `bookcatalogue` hardcodes references to its 
 
 In the second part of this tutorial we are going to use a discovery service.
 
-o learn about registration patterns:
+[NOTE]
+====
+About __registration patterns__
 
 We will use a **self‑registration pattern**. Thus, each service instance is responsible for registering and
 deregistering itself with the service registry.
 Also, if required, a service instance sends heartbeat requests to prevent its registration from expiring.
+====
 
 Services register when they start up:
 


### PR DESCRIPTION
Not sure what the original intention was, but the text "o Learn about registration patterns:" seems to be either incorrectly annotated or not supposed to be there.
I propose making a note admonition block for this paragraph.